### PR TITLE
support message_format to use @metions and auto-detected URLs functions

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -11,7 +11,8 @@ class HipChat
       message:
         from: 'JIRA',
         color: 'yellow',
-        notify: 1
+        notify: 1,
+        message_format: 'html'
 
   getMailByMentionName: (name, cb) ->
     unless name
@@ -65,6 +66,7 @@ class HipChat
       from: params.from or @options.message.from,
       color: params.color or @options.message.color,
       notify: params.notify ? @options.message.notify,
+      message_format: params.message_format or @options.message.message_format
 
     request
       .post(@options.url + 'v1/rooms/message')


### PR DESCRIPTION
Special HipChat features such as @mentions, emoticons, and image previews are NOT supported when using "html" message_format.
